### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme="./Readme.md"
 license-file = "./LICENSE"
 description = "sql comment parser"
 keywords = ["sql","comment"]
-homepage = "https://github.com/wpf375516041/sql-comment-parser"
+repository = "https://github.com/wpf375516041/sql-comment-parser"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.